### PR TITLE
[WIP] iTerm2 like a boss

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,15 @@ streamReply.subscribe(content => {
 
 displayData.subscribe(data => {
   if(data['image/png']) {
+    if(process.env.TERM_PROGRAM === 'iTerm.app') {
+      const outputStream = process.stdout;
+      outputStream.write('\u001b]1337;');
+      outputStream.write('File=inline=1:');
+      outputStream.write(data['image/png']);
+      outputStream.write('\u0007\n');
+      return;
+    }
+
     temp.open('ick-image', (err, info) => {
       if (err) {
         console.error(err);


### PR DESCRIPTION
This adds inline image support for iTerm2.

![screenshot 2016-01-18 23 24 00](https://cloud.githubusercontent.com/assets/836375/12410527/b43721da-be3b-11e5-83b2-c712522d5c1e.png)

HOWEVER, the version of iTerm2 that can handle this is in beta. Running this in iTerm on the current stable release will produce nothing for images. If there's a way to detect the iTerm version, then we can case this off.